### PR TITLE
Improve stripe-lib createInvoice function to expect payment method id

### DIFF
--- a/src/libs/stripe-lib.js
+++ b/src/libs/stripe-lib.js
@@ -120,12 +120,14 @@ class StripeLib {
    */
   async createInvoice(payload) {
     try {
-      const { customerId, description, metadata } = payload;
+
+      const { customerId, description, metadata, methodId } = payload;
       const invoice = await this.stripe.invoices.create({
         customer: customerId,
         collection_method: 'charge_automatically',
         auto_advance: true,
         description,
+        default_payment_method: methodId,
         metadata,
       });
 


### PR DESCRIPTION
# PR Details
Changed strip-lib create method, add method id in payload

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- Please link to the issue here: -->

Closes #issue

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

